### PR TITLE
Change context property of request processing from array to object and add description to necessary suggestion actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ app.post('/cds-services/patient-view-example', (request, response) => {
 app.post('/cds-services/medication-prescribe-example', (request, response) => {
 
   // Parse the request body for the FHIR context provided by the EHR. In this case, the MedicationOrder resource
-  const context = request.body.context[0];
+  const context = request.body.context.medications[0];
 
   // Check if a medication was chosen by the provider to be ordered
   if (context.medicationCodeableConcept) {
@@ -163,6 +163,7 @@ function createMedicationResponseCard(context) {
               actions: [
                 {
                   type: 'create',
+                  description: 'Modifying existing medication order to be Aspirin',
                   resource: newMedicationOrder
                 }
               ]


### PR DESCRIPTION
Currently, the CDS Services tutorial is processing requests for its `medication-prescribe` service in an outdated manner where it treats the `context` property as an array. We should switch this to read off the `medications` field in the context object for appropriate data from an incoming request, since the Sandbox is now updated to form context as an object, instead of an array. Additionally, descriptions are now a required field on a suggestion action, so we should add a relevant message here as well.

@kpshek 
@mjhenkes 
@kolkheang 