### PR TITLE
Remove extra step to parse prefetch response

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ app.get('/cds-services', (request, response) => {
 app.post('/cds-services/patient-view-example', (request, response) => {
 
   // Parse the request body for the Patient prefetch resource
-  const patientResource = request.body.prefetch.requestedPatient.resource;
+  const patientResource = request.body.prefetch.requestedPatient;
   const patientViewCard = {
     cards: [
       {


### PR DESCRIPTION
We need to fix the prefetch parsing to read the returned response directly from the prefetch key, instead of through the extra step of going through a `resource` property.