### PR TITLE
Add ability to run tutorial from a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:11-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+
+EXPOSE 3000
+CMD [ "npm", "run", "start-server" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/usr/src/app/
+      - /usr/src/app/node_modules
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
Add the ability to use docker rather than installing node.js.  This helps in particular with using the tutorial in a workshop setting and keeping the server in a consistent environment.

`docker-compose up --build` will start up a server on localhost:3000 that can be used with sandbox.cds-hooks.org,  with.  Any local code edits will automatically be reflected in the container.