### PR TITLE
Fix reference to patient resource in the payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ app.get('/cds-services', (request, response) => {
 app.post('/cds-services/patient-view-example', (request, response) => {
 
   // Parse the request body for the Patient prefetch resource
-  const patientResource = request.body.prefetch.requestedPatient;
+  const patientResource = request.body.prefetch.requestedPatient.resource;
   const patientViewCard = {
     cards: [
       {


### PR DESCRIPTION
Fix the reference to patient resource in the "patient-view-example" payload.
Sample of the payload is in the wiki https://github.com/cerner/cds-services-tutorial/wiki/Patient-View-Service